### PR TITLE
Add Supabase authentication support

### DIFF
--- a/DripNote/Sources/App/AppDelegate.swift
+++ b/DripNote/Sources/App/AppDelegate.swift
@@ -6,15 +6,20 @@ import DripNoteData
 import DripNoteThirdParty
 
 import FirebaseCore
+import Supabase
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     var container: ModelContainer!
+    var supabaseClient: SupabaseClient!
     
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
         FirebaseApp.configure()
+
+        supabaseClient = SupabaseClient(supabaseURL: URL(string: SupabaseConfig.url)!, supabaseKey: SupabaseConfig.anonKey)
+        DIContainer.shared.register(SupabaseClient.self, instance: supabaseClient)
         
         
         let center = UNUserNotificationCenter.current()

--- a/DripNote/Sources/Core/Supabase/SupabaseConfig.swift
+++ b/DripNote/Sources/Core/Supabase/SupabaseConfig.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum SupabaseConfig {
+    static let url: String = ProcessInfo.processInfo.environment["SUPABASE_URL"] ?? ""
+    static let anonKey: String = ProcessInfo.processInfo.environment["SUPABASE_ANON_KEY"] ?? ""
+}

--- a/DripNote/Sources/DI/DIContainer.swift
+++ b/DripNote/Sources/DI/DIContainer.swift
@@ -1,5 +1,6 @@
 import DripNoteDomain
 import DripNoteData
+import Supabase
 
 import Foundation
 import SwiftData
@@ -44,9 +45,15 @@ private extension DIContainer {
         let dataSource = LocalBrewingRecipeDataSource(modelContext: modelContext)
         let repository = LocalBrewingRecipeRepositoryImpl(dataSource: dataSource)
         register(RecipeUseCase.self, instance: DefaultRecipeUseCase(repository: repository))
-        
+
         let firebaseBrewingrepository = FirestoreBrewingRecipeRepositoryImpl()
         register(FirestoreRecipeUseCase.self, instance: DefaultFirestoreRecipeUseCase(repository: firebaseBrewingrepository))
+
+        if let client = dependencies[String(describing: SupabaseClient.self)] as? SupabaseClient {
+            let authRepository = SupabaseAuthRepositoryImpl(client: client)
+            register(AuthenticationRepository.self, instance: authRepository)
+            register(AuthUseCase.self, instance: DefaultAuthUseCase(repository: authRepository))
+        }
     }
     
     func registerUseCases() {}

--- a/DripNote/Sources/Data/Auth/SupabaseAuthDataSource.swift
+++ b/DripNote/Sources/Data/Auth/SupabaseAuthDataSource.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Supabase
+import DripNoteDomain
+
+final class SupabaseAuthDataSource {
+    private let client: SupabaseClient
+
+    init(client: SupabaseClient) {
+        self.client = client
+    }
+
+    func currentUser() -> AuthUser? {
+        guard let user = client.auth.session?.user else { return nil }
+        return AuthUser(id: user.id.uuidString, email: user.email)
+    }
+
+    func signIn(email: String, password: String) async throws -> AuthUser {
+        let session = try await client.auth.signIn(email: email, password: password)
+        let user = session.user
+        return AuthUser(id: user.id.uuidString, email: user.email)
+    }
+
+    func signUp(email: String, password: String) async throws -> AuthUser {
+        let session = try await client.auth.signUp(email: email, password: password)
+        let user = session.user
+        return AuthUser(id: user.id.uuidString, email: user.email)
+    }
+
+    func signOut() async throws {
+        try await client.auth.signOut()
+    }
+}

--- a/DripNote/Sources/Data/Auth/SupabaseAuthRepositoryImpl.swift
+++ b/DripNote/Sources/Data/Auth/SupabaseAuthRepositoryImpl.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Supabase
+import DripNoteDomain
+
+public final class SupabaseAuthRepositoryImpl: AuthenticationRepository {
+    private let dataSource: SupabaseAuthDataSource
+
+    public init(client: SupabaseClient) {
+        self.dataSource = SupabaseAuthDataSource(client: client)
+    }
+
+    public func currentUser() -> AuthUser? {
+        dataSource.currentUser()
+    }
+
+    public func signIn(email: String, password: String) async throws -> AuthUser {
+        try await dataSource.signIn(email: email, password: password)
+    }
+
+    public func signUp(email: String, password: String) async throws -> AuthUser {
+        try await dataSource.signUp(email: email, password: password)
+    }
+
+    public func signOut() async throws {
+        try await dataSource.signOut()
+    }
+}

--- a/DripNote/Sources/Domain/Entities/AuthUser.swift
+++ b/DripNote/Sources/Domain/Entities/AuthUser.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct AuthUser: Identifiable {
+    public let id: String
+    public let email: String?
+
+    public init(id: String, email: String?) {
+        self.id = id
+        self.email = email
+    }
+}

--- a/DripNote/Sources/Domain/Repositories/AuthenticationRepository.swift
+++ b/DripNote/Sources/Domain/Repositories/AuthenticationRepository.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@MainActor
+public protocol AuthenticationRepository {
+    func currentUser() -> AuthUser?
+    func signIn(email: String, password: String) async throws -> AuthUser
+    func signUp(email: String, password: String) async throws -> AuthUser
+    func signOut() async throws
+}

--- a/DripNote/Sources/Domain/UseCases/Auth/AuthUseCase.swift
+++ b/DripNote/Sources/Domain/UseCases/Auth/AuthUseCase.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+@MainActor
+public protocol AuthUseCase {
+    func currentUser() -> AuthUser?
+    func signIn(email: String, password: String) async throws -> AuthUser
+    func signUp(email: String, password: String) async throws -> AuthUser
+    func signOut() async throws
+}
+
+@MainActor
+public final class DefaultAuthUseCase: AuthUseCase {
+    private let repository: AuthenticationRepository
+
+    public init(repository: AuthenticationRepository) {
+        self.repository = repository
+    }
+
+    public func currentUser() -> AuthUser? {
+        repository.currentUser()
+    }
+
+    public func signIn(email: String, password: String) async throws -> AuthUser {
+        try await repository.signIn(email: email, password: password)
+    }
+
+    public func signUp(email: String, password: String) async throws -> AuthUser {
+        try await repository.signUp(email: email, password: password)
+    }
+
+    public func signOut() async throws {
+        try await repository.signOut()
+    }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -7,6 +7,7 @@ let project = Project(
         .remote(url: "https://github.com/firebase/firebase-ios-sdk.git", requirement: .upToNextMajor(from: "11.9.0")),
         .remote(url: "https://github.com/google/promises.git", requirement: .upToNextMajor(from: "2.3.1")),
         .remote(url: "https://github.com/youtube/youtube-ios-player-helper.git", requirement: .upToNextMajor(from: "1.0.4")),
+        .remote(url: "https://github.com/supabase-community/supabase-swift.git", requirement: .upToNextMajor(from: "0.2.0")),
     ],
         settings: .settings(
         base: [
@@ -160,7 +161,8 @@ let project = Project(
             resources: [],
             dependencies: [
                 .target(name: "DripNoteDomain"),
-                .package(product: "FirebaseFirestore")
+                .package(product: "FirebaseFirestore"),
+                .package(product: "Supabase")
             ]
         ),
         .target(


### PR DESCRIPTION
## Summary
- integrate Supabase package
- create configuration loader and auth domain layer
- implement Supabase auth data source and repository
- register auth dependencies in DI container
- set up Supabase client in `AppDelegate`

## Testing
- `tuist test` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68412c0f59fc8325a99571534276811e